### PR TITLE
Update SDK with new SPOD Endpoints and changed Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The SDK wraps the main Spreadconnect API endpoints:
 | **Subscriptions** | `SubscriptionsApi`  | `spreadconnect.subscriptions.create({...})`    |
 | **Product Types** | `ProductTypesApi`   | `spreadconnect.productTypes.list()`            |
 | **Stocks**        | `StocksApi`         | `spreadconnect.stocks.list()`                  |
+| **Designs**       | `DesignsApi`        | `spreadconnect.designs.upload()`               |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spreadconnect-js-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A SDK for Spreadconnect",
   "main": "dist/index.js",
   "type": "module",

--- a/src/__mock__/article.ts
+++ b/src/__mock__/article.ts
@@ -1,46 +1,51 @@
 import {
-    ArticleCreation,
-    CreateArticleResponse,
-    DeleteArticleParams,
-    DeleteSingleArticleResponse,
-    GetArticleParams,
-    GetArticlesParams,
-    GetArticlesResponse,
-    GetSingleArticleResponse
+  ArticleCreation,
+  CreateArticleResponse,
+  DeleteArticleParams,
+  DeleteSingleArticleResponse,
+  GetArticleParams,
+  GetArticlesParams,
+  GetArticlesResponse,
+  GetSingleArticleResponse,
 } from "../types/spod-types.js";
 
 import { ApiResponse } from "../types/sdk-types.js";
 
 const GetSingleArticleMock: GetSingleArticleResponse = {
-    title: "Test article"
-}
+  title: "Test article",
+};
 
 export const ArticleCreationMock: ArticleCreation = {
-    title: "Test",
-    description: "test",
-    variants: [{
-        productTypeId: 10,
-        appearanceId: 1,
-        sizeId: 1
-    }],
-    configurations: [{
-        image: {
-            url: "image"
-        },
-        view: "FRONT"
-    }]
-}
+  title: "Test",
+  description: "test",
+  variants: [
+    {
+      productTypeId: 10,
+      appearanceId: 1,
+      sizeId: 1,
+    },
+  ],
+  configurations: [
+    {
+      image: {
+        url: "image",
+      },
+      view: "FRONT",
+    },
+  ],
+};
 
-export const GetSingleArticleResponseMock: ApiResponse<GetSingleArticleResponse> = {
+export const GetSingleArticleResponseMock: ApiResponse<GetSingleArticleResponse> =
+  {
     status: 200,
-    data: GetSingleArticleMock
-}
+    data: GetSingleArticleMock,
+  };
 
 export const GetArticlesResponseMock: ApiResponse<GetArticlesResponse> = {
-    status: 200,
-    data: {
-        items: [GetSingleArticleMock],
-        count: 0,
-        limit: 0
-    }
-}
+  status: 200,
+  data: {
+    items: [GetSingleArticleMock],
+    count: 0,
+    limit: 0,
+  },
+};

--- a/src/__mock__/design.ts
+++ b/src/__mock__/design.ts
@@ -1,0 +1,12 @@
+import { ApiResponse, DesignUpload, DesignUploadResponse } from "../types";
+
+export const DesignUploadPropsMock: DesignUpload = {
+  url: "https://example.com/image.png",
+};
+
+export const DesignUploadResponseMock: ApiResponse<DesignUploadResponse> = {
+  status: 200,
+  data: {
+    designId: "mock-design-id-123",
+  },
+};

--- a/src/__mock__/order-type.ts
+++ b/src/__mock__/order-type.ts
@@ -1,26 +1,86 @@
-import { ApiResponse, GetProductTypesResponse, ProductTypes, SizeChart } from "../types";
+import {
+  ApiResponse,
+  GetProductTypesResponse,
+  ProductTypes,
+  SizeChart,
+  GetProductTypeCategoriesResponse,
+  GetProductTypeViewsResponse,
+  GetProductTypeDesignHotspotsResponse,
+  GetProductTypePreviewsResponse,
+} from "../types";
 
 const productType: ProductTypes = {
-    id: "10",
-    customerName: "Test"
-}
+  id: "10",
+  customerName: "Test",
+};
 
 export const SizeChartResponseMock: ApiResponse<SizeChart> = {
-    status: 200,
-    data: {
-        sizeImageUrl: "image"
-    }
-}
+  status: 200,
+  data: {
+    sizeImageUrl: "image",
+  },
+};
 
 export const GetSingleProductTypeResponseMock: ApiResponse<ProductTypes> = {
-    status: 200,
-    data: productType
-}
+  status: 200,
+  data: productType,
+};
 
-export const GetProductTypesResponseMock: ApiResponse<GetProductTypesResponse> = {
+export const GetProductTypesResponseMock: ApiResponse<GetProductTypesResponse> =
+  {
     status: 200,
     data: {
-        items: [productType],
-        
-    }
-}
+      items: [productType],
+    },
+  };
+
+export const GetProductTypeCategoriesResponseMock: ApiResponse<GetProductTypeCategoriesResponse> =
+  {
+    status: 200,
+    data: {
+      categories: [
+        {
+          id: "root",
+          translation: "Root Category",
+          children: [{ id: "child1", translation: "Child Category" }],
+        },
+      ],
+      features: [{ id: "feat1", translation: "Special Feature" }],
+      brands: [{ id: "brand1", translation: "Brand Test" }],
+      genders: [{ id: "gender1", translation: "Unisex" }],
+    },
+  };
+
+export const GetProductTypeViewsResponseMock: ApiResponse<GetProductTypeViewsResponse> =
+  {
+    status: 200,
+    data: {
+      views: [
+        {
+          id: "front",
+          name: "FRONT",
+          hotspots: [{ name: "CHEST_LEFT" }],
+          images: [{ appearanceId: "1", image: "image-url-front.png" }],
+        },
+      ],
+    },
+  };
+
+export const GetProductTypeDesignHotspotsResponseMock: ApiResponse<GetProductTypeDesignHotspotsResponse> =
+  {
+    status: 200,
+    data: {
+      hotspots: [{ name: "CHEST_LEFT" }, { name: "BACK_CENTER" }],
+    },
+  };
+
+export const GetProductTypePreviewsResponseMock: ApiResponse<GetProductTypePreviewsResponse> =
+  {
+    status: 200,
+    data: {
+      images: [
+        { url: "preview-front.png", viewId: "front", viewName: "FRONT" },
+        { url: "preview-back.png", viewId: "back", viewName: "BACK" },
+      ],
+    },
+  };

--- a/src/__mock__/order.ts
+++ b/src/__mock__/order.ts
@@ -1,64 +1,70 @@
-import { ApiResponse, ErrorResponse, GetShipmentsResponse, GetShippingTypesResponse } from "../types";
+import {
+  ApiResponse,
+  ErrorResponse,
+  GetShipmentsResponse,
+  GetShippingTypesResponse,
+} from "../types";
 
 export const CreateOrderMock = {
-    orderItems: [],
-    shipping: {
-        address: {
-            company: "Test",
-            firstName: "Bob",
-            lastName: "Marley",
-            street: "Chill Str. 420",
-            streetAnnex: undefined,
-            city: "Chill city",
-            country: "Chill country",
-            state: undefined,
-            zipCode: "42020"
-        },
-        preferredType: undefined,
-        customerPrice: {
-            amount: 10
-        }
+  orderItems: [],
+  shipping: {
+    address: {
+      company: "Test",
+      firstName: "Bob",
+      lastName: "Marley",
+      street: "Chill Str. 420",
+      streetAnnex: undefined,
+      city: "Chill city",
+      country: "Chill country",
+      state: undefined,
+      zipCode: "42020",
     },
-    phone: "",
-    email: "",
-    externalOrderReference: ""
+    preferredType: undefined,
+    customerPrice: {
+      amount: 10,
+    },
+  },
+  phone: "",
+  email: "",
+  externalOrderReference: "",
 };
 
 export const GetOrderMock = {
-    status: 0,
-    data: {
-        id: 10
-    }
+  status: 0,
+  data: {
+    id: 10,
+  },
 };
 
 export const ErrorResponseMock: ApiResponse<ErrorResponse> = {
-    status: 0,
-    data: {
-        orderId: 10,
-        reason: "test",
-    }
+  status: 0,
+  data: {
+    orderId: 10,
+    reason: "test",
+  },
 };
 
 export const GetShippingTypesMock: ApiResponse<GetShipmentsResponse> = {
-    status: 0,
-    data: [
-        {
-            id: 1,
-            orderId: 10
-        }
-    ]
-}
-
-export const GetAvailableShippingTypesMock: ApiResponse<GetShippingTypesResponse> = {
-    status: 0,
-    data: [
-        {
-            id: "1",
-            company: "Chill corp",
-            name: "Chill shipping",
-            price: {
-                amount: 10,
-            }
-        }
-    ]
+  status: 0,
+  data: [
+    {
+      id: 1,
+      orderId: 10,
+    },
+  ],
 };
+
+export const GetAvailableShippingTypesMock: ApiResponse<GetShippingTypesResponse> =
+  {
+    status: 0,
+    data: [
+      {
+        id: "1",
+        company: "Chill corp",
+        name: "Chill shipping",
+        price: {
+          amount: 10,
+        },
+      },
+    ],
+  };

--- a/src/__mock__/stock.ts
+++ b/src/__mock__/stock.ts
@@ -1,4 +1,8 @@
-import { ApiResponse, GetStocksResponse } from "../types";
+import {
+  ApiResponse,
+  GetStocksResponse,
+  GetStockByProductTypeResponse,
+} from "../types";
 
 export const StocksResponseMock: ApiResponse<GetStocksResponse> = {
   status: 200,
@@ -15,3 +19,22 @@ export const StockResponseMock: ApiResponse<number> = {
   status: 200,
   data: 10,
 };
+
+export const GetStockByProductTypeResponseMock: ApiResponse<GetStockByProductTypeResponse> =
+  {
+    status: 200,
+    data: {
+      variants: [
+        {
+          appearanceId: "1",
+          sizeId: "M",
+          stock: 42,
+        },
+        {
+          appearanceId: "2",
+          sizeId: "L",
+          stock: 10,
+        },
+      ],
+    },
+  };

--- a/src/__mock__/subscription.ts
+++ b/src/__mock__/subscription.ts
@@ -1,34 +1,37 @@
 import { ApiResponse, GetSubscriptionsResponse, Subscription } from "../types";
 
 export const CreateSubscriptionPropsMock: Subscription = {
-    eventType: "Shipment.sent"
-}
+  eventType: "Shipment.sent",
+  url: "https://example.com/webhook",
+};
 
 export const CreateSubscriptionResponseMock: ApiResponse<void> = {
-    status: 200
-}
+  status: 200,
+};
 
 export const DeleteSubscriptionResponseMock: ApiResponse<void> = {
-    status: 200
-}
+  status: 200,
+};
 
 export const SimulateOrderCancelledResponseMock: ApiResponse<void> = {
-    status: 200
-}
+  status: 200,
+};
 
 export const SimulateOrderProcessedResponseMock: ApiResponse<void> = {
-    status: 200
-}
+  status: 200,
+};
 
 export const SimulateShipmentSentResponseMock: ApiResponse<void> = {
-    status: 200
-}
+  status: 200,
+};
 
-export const GetSubscriptionsResponseMock: ApiResponse<GetSubscriptionsResponse> = {
+export const GetSubscriptionsResponseMock: ApiResponse<GetSubscriptionsResponse> =
+  {
     status: 200,
     data: [
-        {
-            eventType: "Shipment.sent"
-        }
-    ]
-}
+      {
+        eventType: "Shipment.sent",
+        url: "https://example.com/webhook",
+      },
+    ],
+  };

--- a/src/__test__/api/designs-api.test.ts
+++ b/src/__test__/api/designs-api.test.ts
@@ -1,0 +1,86 @@
+import {
+  DesignUploadPropsMock,
+  DesignUploadResponseMock,
+} from "../../__mock__/design";
+import { DesignsApi } from "../../api/designs-api";
+import { DESIGNS_PATH } from "../../endpoints/spod-endpoints";
+import { HttpClient } from "../../http/http-client";
+
+jest.mock("../../http/http-client");
+const MockedHttpClient = HttpClient as jest.MockedClass<typeof HttpClient>;
+
+describe("Designs API", () => {
+  let httpClient: jest.Mocked<HttpClient>;
+  let api: DesignsApi;
+
+  beforeEach(() => {
+    MockedHttpClient.mockClear();
+    httpClient = new MockedHttpClient(
+      "",
+      "",
+    ) as unknown as jest.Mocked<HttpClient>;
+    api = new DesignsApi(httpClient);
+  });
+
+  test("Upload design with url", async () => {
+    httpClient.request.mockResolvedValueOnce(DesignUploadResponseMock);
+
+    const result = await api.upload(DesignUploadPropsMock);
+
+    expect(result).toEqual(DesignUploadResponseMock);
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "POST",
+      `${DESIGNS_PATH}/upload`,
+      expect.any(FormData),
+    );
+  });
+
+  test("Upload design with file", async () => {
+    httpClient.request.mockResolvedValueOnce({
+      status: 200,
+      data: { designId: "file-upload-id" },
+    });
+
+    const file = new Blob(["hello"], { type: "text/plain" });
+    const props = { file };
+
+    const result = await api.upload(props);
+
+    expect(result).toEqual({
+      status: 200,
+      data: { designId: "file-upload-id" },
+    });
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "POST",
+      `${DESIGNS_PATH}/upload`,
+      expect.any(FormData),
+    );
+  });
+
+  test("Upload design with file and url", async () => {
+    httpClient.request.mockResolvedValueOnce({
+      status: 200,
+      data: { designId: "both-id" },
+    });
+
+    const file = new Blob(["x"], { type: "text/plain" });
+    const props = { file, url: "https://example.com/test.png" };
+
+    const result = await api.upload(props);
+
+    expect(result).toEqual({ status: 200, data: { designId: "both-id" } });
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "POST",
+      `${DESIGNS_PATH}/upload`,
+      expect.any(FormData),
+    );
+  });
+
+  test("Throws on network error", async () => {
+    httpClient.request.mockRejectedValueOnce(new Error("Network Error"));
+
+    await expect(api.upload(DesignUploadPropsMock)).rejects.toThrow(
+      "Network Error",
+    );
+  });
+});

--- a/src/__test__/api/orders-api.test.ts
+++ b/src/__test__/api/orders-api.test.ts
@@ -67,7 +67,7 @@ describe("Orders API", () => {
     expect(order).toEqual(GetOrderMock);
 
     expect(httpClient.request).toHaveBeenCalledWith(
-      "UPDATE",
+      "PUT",
       `${ORDERS_PATH}/${id}`,
       CreateOrderMock,
     );

--- a/src/__test__/api/product-types-api.test.ts
+++ b/src/__test__/api/product-types-api.test.ts
@@ -2,6 +2,10 @@ import {
   GetProductTypesResponseMock,
   GetSingleProductTypeResponseMock,
   SizeChartResponseMock,
+  GetProductTypeCategoriesResponseMock,
+  GetProductTypeViewsResponseMock,
+  GetProductTypeDesignHotspotsResponseMock,
+  GetProductTypePreviewsResponseMock,
 } from "../../__mock__/order-type";
 import { ProductTypesApi } from "../../api/product-types-api";
 import { PRODUCT_TYPES_PATH } from "../../endpoints/spod-endpoints";
@@ -61,6 +65,83 @@ describe("Product Types API", () => {
     expect(httpClient.request).toHaveBeenCalledWith(
       "GET",
       `${PRODUCT_TYPES_PATH}/${id}/size-chart`,
+    );
+  });
+
+  test("Get product type category tree", async () => {
+    httpClient.request.mockResolvedValueOnce(
+      GetProductTypeCategoriesResponseMock,
+    );
+
+    const res = await api.get_category_tree();
+
+    expect(res).toEqual(GetProductTypeCategoriesResponseMock);
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "GET",
+      `${PRODUCT_TYPES_PATH}/categories`,
+    );
+  });
+
+  test("Get categories by product type", async () => {
+    const id = "10";
+    httpClient.request.mockResolvedValueOnce(
+      GetProductTypeCategoriesResponseMock,
+    );
+
+    const res = await api.get_categories_by_product_type(id);
+
+    expect(res).toEqual(GetProductTypeCategoriesResponseMock);
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "GET",
+      `${PRODUCT_TYPES_PATH}/${id}/categories`,
+    );
+  });
+
+  test("Get views", async () => {
+    const id = "10";
+    httpClient.request.mockResolvedValueOnce(GetProductTypeViewsResponseMock);
+
+    const res = await api.get_views(id);
+
+    expect(res).toEqual(GetProductTypeViewsResponseMock);
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "GET",
+      `${PRODUCT_TYPES_PATH}/${id}/views`,
+    );
+  });
+
+  test("Get design hotspots", async () => {
+    const productTypeId = "10";
+    const designId = "123";
+    httpClient.request.mockResolvedValueOnce(
+      GetProductTypeDesignHotspotsResponseMock,
+    );
+
+    const res = await api.get_design_hotspots(productTypeId, designId);
+
+    expect(res).toEqual(GetProductTypeDesignHotspotsResponseMock);
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "GET",
+      `${PRODUCT_TYPES_PATH}/${productTypeId}/hotspots/design/${designId}`,
+    );
+  });
+
+  test("Get previews", async () => {
+    const productTypeId = "10";
+    const body = {
+      configurations: [{ designId: "123", hotspot: "CHEST_LEFT" }],
+    };
+    httpClient.request.mockResolvedValueOnce(
+      GetProductTypePreviewsResponseMock,
+    );
+
+    const res = await api.get_previews(productTypeId, body);
+
+    expect(res).toEqual(GetProductTypePreviewsResponseMock);
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "POST",
+      `${PRODUCT_TYPES_PATH}/${productTypeId}/previews`,
+      body,
     );
   });
 

--- a/src/__test__/api/stock-api.test.ts
+++ b/src/__test__/api/stock-api.test.ts
@@ -1,4 +1,8 @@
-import { StockResponseMock, StocksResponseMock } from "../../__mock__/stock";
+import {
+  StockResponseMock,
+  StocksResponseMock,
+  GetStockByProductTypeResponseMock,
+} from "../../__mock__/stock";
 import { StocksApi } from "../../api/stocks-api";
 import { STOCKS_PATH } from "../../endpoints/spod-endpoints";
 import { HttpClient } from "../../http/http-client";
@@ -47,6 +51,19 @@ describe("Orders API", () => {
     expect(httpClient.request).toHaveBeenCalledWith(
       "GET",
       `${STOCKS_PATH}/${sku}`,
+    );
+  });
+
+  test("Get stock by product type", async () => {
+    const id = "10";
+    httpClient.request.mockResolvedValueOnce(GetStockByProductTypeResponseMock);
+
+    const stock = await api.get_by_productType(id);
+
+    expect(stock).toEqual(GetStockByProductTypeResponseMock);
+    expect(httpClient.request).toHaveBeenCalledWith(
+      "GET",
+      `${STOCKS_PATH}/productType/${id}`,
     );
   });
 

--- a/src/__test__/http/http-client.test.ts
+++ b/src/__test__/http/http-client.test.ts
@@ -120,4 +120,31 @@ describe("HttpClient", () => {
     expect(res.data).toBeUndefined();
     expect(res.rawBody).toBe("invalid-json");
   });
+
+  it("should send FormData without Content-Type header", async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve("{}"),
+    });
+
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new Blob(["test"], { type: "text/plain" }),
+      "test.txt",
+    );
+
+    await client.request("POST", "/upload", formData);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/upload",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "X-SPOD-ACCESS-TOKEN": token,
+        },
+        body: formData,
+      }),
+    );
+  });
 });

--- a/src/__test__/spreadconnect.test.ts
+++ b/src/__test__/spreadconnect.test.ts
@@ -7,6 +7,7 @@ import { OrdersApi } from "../api/orders-api.js";
 import { SubscriptionsApi } from "../api/subscriptions-api.js";
 import { ProductTypesApi } from "../api/product-types-api.js";
 import { StocksApi } from "../api/stocks-api.js";
+import { DesignsApi } from "../api/designs-api.js";
 
 jest.mock("../http/http-client.js");
 jest.mock("../api/articles-api.js");
@@ -14,6 +15,7 @@ jest.mock("../api/orders-api.js");
 jest.mock("../api/subscriptions-api.js");
 jest.mock("../api/product-types-api.js");
 jest.mock("../api/stocks-api.js");
+jest.mock("../api/designs-api.js");
 
 describe("Spreadconnect", () => {
   const baseUrl = "https://api.example.com";
@@ -41,12 +43,14 @@ describe("Spreadconnect", () => {
     expect(SubscriptionsApi).toHaveBeenCalledWith(fakeClient);
     expect(ProductTypesApi).toHaveBeenCalledWith(fakeClient);
     expect(StocksApi).toHaveBeenCalledWith(fakeClient);
+    expect(DesignsApi).toHaveBeenCalledWith(fakeClient);
 
     expect(spreadconnect.articles).toBeInstanceOf(ArticlesApi);
     expect(spreadconnect.orders).toBeInstanceOf(OrdersApi);
     expect(spreadconnect.subscriptions).toBeInstanceOf(SubscriptionsApi);
     expect(spreadconnect.productTypes).toBeInstanceOf(ProductTypesApi);
     expect(spreadconnect.stocks).toBeInstanceOf(StocksApi);
+    expect(spreadconnect.designs).toBeInstanceOf(DesignsApi);
   });
 
   it("should store API instances on the class", () => {
@@ -57,5 +61,6 @@ describe("Spreadconnect", () => {
     expect(spreadconnect).toHaveProperty("subscriptions");
     expect(spreadconnect).toHaveProperty("productTypes");
     expect(spreadconnect).toHaveProperty("stocks");
+    expect(spreadconnect).toHaveProperty("designs");
   });
 });

--- a/src/api/designs-api.ts
+++ b/src/api/designs-api.ts
@@ -1,0 +1,38 @@
+import { DESIGNS_PATH } from "../endpoints/spod-endpoints.js";
+import { HttpClient } from "../http/http-client.js";
+import { DesignUpload, DesignUploadResponse } from "../types/spod-types.js";
+
+export class DesignsApi {
+  constructor(private client: HttpClient) {}
+
+  /**
+   * Uploads a new design to Spreadconnect.
+   *
+   * This can either be done by directly uploading a file (binary data)
+   * or by providing a public image URL, which Spreadconnect will fetch.
+   *
+   * Send a POST request to `/designs/upload` with `multipart/form-data`.
+   *
+   * @param props - The design upload details.
+   * @param [props.file] - The binary file (image) to upload.
+   * @param [props.url] - Optionally a public image URL to fetch.
+   *
+   * @returns A promise that resolves with a reusable `designId`.
+   */
+  upload(props: DesignUpload) {
+    const formData = new FormData();
+
+    if (props.file) {
+      formData.append("file", props.file);
+    }
+    if (props.url) {
+      formData.append("url", props.url);
+    }
+
+    return this.client.request<DesignUploadResponse>(
+      "POST",
+      `${DESIGNS_PATH}/upload`,
+      formData,
+    );
+  }
+}

--- a/src/api/orders-api.ts
+++ b/src/api/orders-api.ts
@@ -33,7 +33,7 @@ export class OrdersApi {
   /**
    * Updates an existing order.
    *
-   * Sends an UPDATE request to the `/orders/{orderId}` endpoint with the updated order details.
+   * Sends an PUT request to the `/orders/{orderId}` endpoint with the updated order details.
    *
    * @param orderId - The ID of the order to update.
    * @param props - The updated order data.
@@ -42,7 +42,7 @@ export class OrdersApi {
    */
   update(orderId: string, props: UpdateOrder) {
     return this.client.request<UpdateOrderResponse>(
-      "UPDATE",
+      "PUT",
       `${ORDERS_PATH}/${orderId}`,
       props,
     );

--- a/src/api/product-types-api.ts
+++ b/src/api/product-types-api.ts
@@ -4,6 +4,10 @@ import {
   GetProductTypesResponse,
   GetSingleProductTypesResponse,
   GetSingleSizeChartResponse,
+  GetProductTypeCategoriesResponse,
+  GetProductTypeViewsResponse,
+  GetProductTypeDesignHotspotsResponse,
+  GetProductTypePreviewsResponse,
 } from "../types/spod-types.js";
 
 export class ProductTypesApi {
@@ -56,6 +60,95 @@ export class ProductTypesApi {
     return this.client.request<GetSingleSizeChartResponse>(
       "GET",
       `${PRODUCT_TYPES_PATH}/${productTypeId}/size-chart`,
+    );
+  }
+
+  /**
+   * Retrieves the complete category tree of product types.
+   *
+   * Sends a GET request to `/productTypes/categories`.
+   *
+   * @returns A promise that resolves with the full category tree including categories, features, brands and genders.
+   */
+  get_category_tree() {
+    return this.client.request<GetProductTypeCategoriesResponse>(
+      "GET",
+      `${PRODUCT_TYPES_PATH}/categories`,
+    );
+  }
+
+  /**
+   * Retrieves the categories assigned to a specific product type.
+   *
+   * Sends a GET request to `/productTypes/{productTypeId}/categories`.
+   *
+   * @param productTypeId - The ID of the product type to retrieve categories for.
+   *
+   * @returns A promise that resolves with the category information for the given product type.
+   */
+  get_categories_by_product_type(productTypeId: string) {
+    return this.client.request<GetProductTypeCategoriesResponse>(
+      "GET",
+      `${PRODUCT_TYPES_PATH}/${productTypeId}/categories`,
+    );
+  }
+
+  /**
+   * Retrieves all views (front, back, etc.), including hotspots and images, for a given product type.
+   *
+   * Sends a GET request to `/productTypes/{productTypeId}/views`.
+   *
+   * @param productTypeId - The ID of the product type to retrieve views for.
+   *
+   * @returns A promise that resolves with the views including hotspots and images.
+   */
+  get_views(productTypeId: string) {
+    return this.client.request<GetProductTypeViewsResponse>(
+      "GET",
+      `${PRODUCT_TYPES_PATH}/${productTypeId}/views`,
+    );
+  }
+
+  /**
+   * Retrieves the available hotspots for a specific product type and design.
+   *
+   * Sends a GET request to `/productTypes/{productTypeId}/hotspots/design/{designId}`.
+   *
+   * @param productTypeId - The ID of the product type to retrieve hotspots for.
+   * @param designId - The ID of the design to check against.
+   *
+   * @returns A promise that resolves with the available hotspots for the given design.
+   */
+  get_design_hotspots(productTypeId: string, designId: string) {
+    return this.client.request<GetProductTypeDesignHotspotsResponse>(
+      "GET",
+      `${PRODUCT_TYPES_PATH}/${productTypeId}/hotspots/design/${designId}`,
+    );
+  }
+
+  /**
+   * Retrieves preview images for a product type given hotspot-design configurations.
+   *
+   * Sends a POST request to `/productTypes/{productTypeId}/previews`.
+   *
+   * @param productTypeId - The ID of the product type.
+   * @param body - The preview request body, including configurations, appearanceId, width and height.
+   *
+   * @returns A promise that resolves with preview images.
+   */
+  get_previews(
+    productTypeId: string,
+    body: {
+      configurations: { designId: string; hotspot: string }[];
+      appearanceId?: string;
+      width?: number;
+      height?: number;
+    },
+  ) {
+    return this.client.request<GetProductTypePreviewsResponse>(
+      "POST",
+      `${PRODUCT_TYPES_PATH}/${productTypeId}/previews`,
+      body,
     );
   }
 }

--- a/src/api/stocks-api.ts
+++ b/src/api/stocks-api.ts
@@ -4,6 +4,7 @@ import {
   GetStockResponse,
   GetStocksParams,
   GetStocksResponse,
+  GetStockByProductTypeResponse,
 } from "../types/spod-types.js";
 
 export class StocksApi {
@@ -41,5 +42,21 @@ export class StocksApi {
    */
   get(sku: string) {
     return this.client.request<number>("GET", `${STOCKS_PATH}/${sku}`);
+  }
+
+  /**
+   * Retrieves the available stock for a specific product type with all its variants.
+   *
+   * Sends a GET request to the `/stock/productType/{productTypeId}` endpoint.
+   *
+   * @param productTypeId - The ID of the product type to retrieve stock for.
+   *
+   * @returns A promise that resolves with the stock information grouped by variants (appearance + size).
+   */
+  get_by_productType(productTypeId: string) {
+    return this.client.request<GetStockByProductTypeResponse>(
+      "GET",
+      `${STOCKS_PATH}/productType/${productTypeId}`,
+    );
   }
 }

--- a/src/api/subscriptions-api.ts
+++ b/src/api/subscriptions-api.ts
@@ -23,7 +23,7 @@ export class SubscriptionsApi {
    *
    * @param props - The subscription data.
    * @param props.eventType - The type of event to subscribe to (required).
-   * @param [props.url] - The URL to which event notifications will be sent.
+   * @param props.url - The URL to which event notifications will be sent.
    * @param [props.secret] - A secret used for verifying webhook payloads.
    *
    * @returns A promise that resolves when the subscription is successfully created.

--- a/src/endpoints/spod-endpoints.ts
+++ b/src/endpoints/spod-endpoints.ts
@@ -8,11 +8,11 @@ export const AUTHENTICATION_PATH = "/authentication";
 
 // Articles
 export const ARTICLES_PATH = "/articles";
-export const ARTICLE_BY_ID_PATH = "/articles/{articleId}"; // e.g., /articles/123
+export const ARTICLE_BY_ID_PATH = "/articles/{articleId}";
 
 // Orders
 export const ORDERS_PATH = "/orders";
-export const ORDER_BY_ID_PATH = "/orders/{orderId}"; // e.g., /orders/456
+export const ORDER_BY_ID_PATH = "/orders/{orderId}";
 export const ORDER_SHIPPING_TYPES_PATH = "/orders/{orderId}/shippingTypes";
 export const ORDER_SET_SHIPPING_TYPE_PATH = "/orders/{orderId}/shippingType";
 export const ORDER_CONFIRM_PATH = "/orders/{orderId}/confirm";
@@ -21,22 +21,25 @@ export const ORDER_SHIPMENTS_PATH = "/orders/{orderId}/shipments";
 
 // Order Event Simulations
 export const ORDER_SIMULATE_CANCELLED_EVENT_PATH =
-    "/orders/{orderId}/simulate/order-cancelled";
+  "/orders/{orderId}/simulate/order-cancelled";
 export const ORDER_SIMULATE_PROCESSED_EVENT_PATH =
-    "/orders/{orderId}/simulate/order-processed";
+  "/orders/{orderId}/simulate/order-processed";
 export const ORDER_SIMULATE_SHIPMENT_SENT_EVENT_PATH =
-    "/orders/{orderId}/simulate/shipment-sent";
+  "/orders/{orderId}/simulate/shipment-sent";
 
 // Subscriptions
 export const SUBSCRIPTIONS_PATH = "/subscriptions";
-export const SUBSCRIPTION_BY_ID_PATH = "/subscriptions/{subscriptionId}"; // e.g., /subscriptions/789
+export const SUBSCRIPTION_BY_ID_PATH = "/subscriptions/{subscriptionId}";
 
 // Product Types
 export const PRODUCT_TYPES_PATH = "/productTypes";
-export const PRODUCT_TYPE_BY_ID_PATH = "/productTypes/{productTypeId}"; // e.g., /productTypes/101
+export const PRODUCT_TYPE_BY_ID_PATH = "/productTypes/{productTypeId}";
 export const PRODUCT_TYPE_SIZE_CHART_PATH =
-    "/productTypes/{productTypeId}/size-chart";
+  "/productTypes/{productTypeId}/size-chart";
 
 // Stock
 export const STOCKS_PATH = "/stock";
-export const STOCK_BY_SKU_PATH = "/stock/{sku}"; // e.g., 
+export const STOCK_BY_SKU_PATH = "/stock/{sku}";
+
+// Design
+export const DESIGNS_PATH = "/designs";

--- a/src/http/http-client.ts
+++ b/src/http/http-client.ts
@@ -17,13 +17,24 @@ export class HttpClient {
     if (queryParams && Object.keys(queryParams).length > 0) {
       url += "?" + toQueryString(queryParams);
     }
+
+    const headers: Record<string, string> = {
+      "X-SPOD-ACCESS-TOKEN": this.token,
+    };
+
+    let fetchBody: BodyInit | undefined;
+
+    if (body instanceof FormData) {
+      fetchBody = body;
+    } else if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      fetchBody = JSON.stringify(body);
+    }
+
     const result = await fetch(url, {
       method,
-      headers: {
-        "X-SPOD-ACCESS-TOKEN": this.token,
-        "Content-Type": "application/json",
-      },
-      body: body ? JSON.stringify(body) : undefined,
+      headers,
+      body: fetchBody,
     });
 
     const text = await result.text();

--- a/src/spreadconnect.ts
+++ b/src/spreadconnect.ts
@@ -4,6 +4,7 @@ import { OrdersApi } from "./api/orders-api.js";
 import { SubscriptionsApi } from "./api/subscriptions-api.js";
 import { ProductTypesApi } from "./api/product-types-api.js";
 import { StocksApi } from "./api/stocks-api.js";
+import { DesignsApi } from "./api/designs-api.js";
 
 export class Spreadconnect {
   public articles: ArticlesApi;
@@ -11,6 +12,7 @@ export class Spreadconnect {
   public subscriptions: SubscriptionsApi;
   public productTypes: ProductTypesApi;
   public stocks: StocksApi;
+  public designs: DesignsApi;
 
   constructor({ baseUrl, token }: { baseUrl: string; token: string }) {
     const client = new HttpClient(baseUrl, token);
@@ -19,5 +21,6 @@ export class Spreadconnect {
     this.subscriptions = new SubscriptionsApi(client);
     this.productTypes = new ProductTypesApi(client);
     this.stocks = new StocksApi(client);
+    this.designs = new DesignsApi(client);
   }
 }

--- a/src/types/spod-types.ts
+++ b/src/types/spod-types.ts
@@ -53,6 +53,7 @@ export type ArticleVariant = {
   sizeName?: string;
   sku?: string;
   d2cPrice?: number;
+  b2bPrice?: number;
   imageIds?: number[];
 };
 
@@ -68,8 +69,10 @@ export type ArticleImage = {
 export type ArticleConfiguration = {
   image: {
     url: string;
+    designId?: string;
   };
   view: "FRONT" | "BACK" | "LEFT" | "RIGHT" | "HOOD_LEFT" | "HOOD_RIGHT";
+  hotspot?: string;
 };
 
 // ==========================================
@@ -94,6 +97,7 @@ export type Order = {
 
 export type CreateOrder = {
   orderItems: CreateOrderItem[];
+  oneTimeItems?: OneTimeItem[];
   shipping: {
     address: Address;
     fromAddress?: Address;
@@ -112,6 +116,7 @@ export type CreateOrder = {
 
 export type UpdateOrder = {
   orderItems: CreateOrderItem[];
+  oneTimeItems?: OneTimeItem[];
   shipping: {
     address: Address;
     fromAddress?: Address;
@@ -133,6 +138,23 @@ export type CreateOrderItem = {
   quantity: number;
   externalOrderItemReference?: string;
   customerPrice: CustomerPrice;
+};
+
+export type OneTimeItem = {
+  quantityItems?: QuantityItem[];
+  configurations?: ArticleConfiguration[];
+  productTypeId?: number;
+  externalOrderItemReference?: string;
+  customerPricePerItem?: {
+    amount: number;
+    currency?: string;
+  };
+};
+
+export type QuantityItem = {
+  quantity?: number;
+  sizeId?: number;
+  appearanceId?: object;
 };
 
 export type GetOrderItem = {
@@ -248,7 +270,7 @@ export type Address = {
 export type Subscription = {
   readonly id?: number;
   eventType: EventType;
-  url?: string;
+  url: string;
   secret?: string;
 };
 
@@ -298,6 +320,73 @@ export type ProductView =
   | "HOOD_RIGHT";
 
 // ==========================================
+// Category Types
+// ==========================================
+export type CategoryNode = {
+  id?: string;
+  translation?: string;
+  children?: CategoryNode[]; // recursive
+};
+
+export type Feature = {
+  id?: string;
+  translation?: string;
+};
+
+export type BrandCategory = {
+  id?: string;
+  translation?: string;
+};
+
+export type Gender = {
+  id?: string;
+  translation?: string;
+};
+
+export type Categories = {
+  categories?: CategoryNode[];
+  features?: Feature[];
+  brands?: BrandCategory[];
+  genders?: Gender[];
+};
+
+// ==========================================
+// View Types
+// ==========================================
+export type ViewHotspot = {
+  name?: string; // e.g. "CHEST_LEFT"
+};
+
+export type ViewImage = {
+  appearanceId: string;
+  image: string;
+};
+
+export type View = {
+  name?: string;
+  id?: string;
+  hotspots?: ViewHotspot[];
+  images?: ViewImage[];
+};
+
+export type Views = {
+  views?: View[];
+};
+
+// ==========================================
+// Preview Types
+// ==========================================
+export type PreviewImage = {
+  url?: string;
+  viewId?: string;
+  viewName?: string;
+};
+
+export type Preview = {
+  images?: PreviewImage[];
+};
+
+// ==========================================
 // Size Chart Types
 // ==========================================
 
@@ -331,7 +420,26 @@ export type GetStocksResponse = {
   offset?: number;
 };
 
+export type StockVariantByProductType = {
+  appearanceId: string;
+  sizeId: string;
+  stock: number;
+};
+
+export type GetStockByProductTypeResponse = {
+  variants?: StockVariantByProductType[];
+};
+
 export type GetStockResponse = number;
+
+// ==========================================
+// Designs Types
+// ==========================================
+
+export type DesignUpload = {
+  file?: Blob;
+  url?: string;
+};
 
 // ==========================================
 // Error Types
@@ -398,3 +506,20 @@ export type GetSingleSizeChartResponse = SizeChart;
 
 // Subscription Responses
 export type GetSubscriptionsResponse = Subscription[];
+
+// Category Responses
+export type GetProductTypeCategoriesResponse = Categories;
+
+// Views Responses
+export type GetProductTypeViewsResponse = Views;
+export type GetProductTypeDesignHotspotsResponse = {
+  hotspots?: { name?: string }[];
+};
+
+// Preview Responses
+export type GetProductTypePreviewsResponse = Preview;
+
+// Design Responses
+export type DesignUploadResponse = {
+  designId: string;
+};


### PR DESCRIPTION
## Pull Request Summary

This PR brings our Spreadconnect SDK in sync with the latest OpenAPI specification and ensures full test coverage across all modules.

### Types (`spod-types.ts`)
- **ArticleVariant**: added `b2bPrice`.
- **ArticleConfiguration**: added optional `designId` and `hotspot`.
- **CreateOrder / UpdateOrder**: added `oneTimeItems` support.
- Introduced `OneTimeItem` and `QuantityItem` types.
- **Subscription**: `url` field is now required.
- Added new entity types:
  - `Categories`, `CategoryNode`, `Feature`, `BrandCategory`, `Gender`
  - `Views`, `View`, `ViewHotspot`, `ViewImage`
  - `Preview`, `PreviewImage`
  - `StockVariantByProductType`, `GetStockByProductTypeResponse`
  - `DesignUpload`, `DesignUploadResponse`

### API Changes
- **OrdersApi**
  - Fixed `update` method to use `PUT` instead of the incorrect `"UPDATE"`.
- **ProductTypesApi**
  - Added:
    - `get_category_tree()` → `/productTypes/categories`
    - `get_categories_by_product_type(id)` → `/productTypes/{id}/categories`
    - `get_views(id)` → `/productTypes/{id}/views`
    - `get_design_hotspots(productTypeId, designId)` → `/productTypes/{id}/hotspots/design/{designId}`
    - `get_previews(productTypeId, body)` → `/productTypes/{id}/previews`
- **StocksApi**
  - Added `get_by_productType(productTypeId)` for `/stock/productType/{productTypeId}`.
- **DesignsApi**
  - New API class with `upload()` for `/designs/upload`, supports both file and URL uploads via `FormData`.

### HttpClient
- Improved body handling:
  - JSON requests still use `application/json`.
  - Automatically detects `FormData` and leaves `Content-Type` unset (browser sets correct multipart boundary).

### Tests
- Updated:
  - `OrdersApi.update` test expects `PUT`.
  - Subscription mocks now include required `url`.
- Added new test coverage for:
  - **DesignsApi**: upload with URL, file, both, and error handling.
  - **StocksApi**: `get_by_productType`.
  - **ProductTypesApi**: category tree, categories by product type, views, design hotspots, previews.
  - **HttpClient**: FormData branch.
  
### TBD
- Wrong return type for productTypes.list() method
- SPOD returns array without items property, but in Schema items property is defined
